### PR TITLE
Fix Sweet 16 bracket reconstruction and entry pick resolution

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,2 +1,2 @@
 streamlit>=1.55.0
-bigdance>=0.8.2
+bigdance>=0.8.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bigdance"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
   "numpy>=1.23",
   "pandas>=1.5",

--- a/src/bigdance/__init__.py
+++ b/src/bigdance/__init__.py
@@ -27,7 +27,7 @@ from .cbb_brackets import Bracket, Game, Pool, Team
 from .espn_tc_scraper import ESPNApi, GameImportanceAnalyzer
 from .wn_cbb_scraper import Matchups, Schedule, Standings, elo_prob
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"
 __author__ = "Taylor Firman"
 __email__ = "tefirman@gmail.com"
 

--- a/src/bigdance/bigdance_integration.py
+++ b/src/bigdance/bigdance_integration.py
@@ -3,7 +3,7 @@
 @File    :   bigdance_integration.py
 @Time    :   2025/01/19
 @Author  :   Taylor Firman
-@Version :   0.8.2
+@Version :   0.8.3
 @Contact :   tefirman@gmail.com
 @Desc    :   Integration module between Warren Nolan scraper and bracket simulator
 """

--- a/src/bigdance/bracket_analysis.py
+++ b/src/bigdance/bracket_analysis.py
@@ -3,7 +3,7 @@
 @File    :   bracket_analysis.py
 @Time    :   2024/02/13
 @Author  :   Taylor Firman
-@Version :   0.8.2
+@Version :   0.8.3
 @Contact :   tefirman@gmail.com
 @Desc    :   Analyzing trends in March Madness bracket pool simulations
 """

--- a/src/bigdance/espn_tc_scraper.py
+++ b/src/bigdance/espn_tc_scraper.py
@@ -69,11 +69,39 @@ class ESPNApi:
             logger.warning(f"Could not load Standings: {e}")
 
     def fetch_challenge(self) -> dict:
-        """Fetch the master challenge data (propositions, scoring periods, etc.)."""
+        """Fetch the master challenge data (propositions, scoring periods, etc.).
+
+        ESPN only returns propositions for the current scoring period.  To
+        build a complete outcome map (needed for resolving entry picks that
+        reference earlier rounds), we fetch each prior period's propositions
+        and merge them into the response.
+        """
         url = f"{self.GAMBIT_API_BASE}/{self.challenge_slug}"
         resp = requests.get(url, timeout=30)
         resp.raise_for_status()
-        return dict(resp.json())
+        data = dict(resp.json())
+
+        # Collect proposition IDs already present (current period)
+        current_prop_ids = {p["id"] for p in data.get("propositions", [])}
+        current_period = data.get("currentScoringPeriod", {}).get("id", 1)
+
+        # Fetch propositions from prior scoring periods
+        for period in data.get("scoringPeriods", []):
+            pid = period.get("id", 0)
+            if pid >= current_period:
+                continue
+            try:
+                prior_resp = requests.get(url, params={"scoringPeriodId": pid}, timeout=30)
+                prior_resp.raise_for_status()
+                prior_data = prior_resp.json()
+                for prop in prior_data.get("propositions", []):
+                    if prop["id"] not in current_prop_ids:
+                        data["propositions"].append(prop)
+                        current_prop_ids.add(prop["id"])
+            except Exception as e:
+                logger.warning(f"Could not fetch scoring period {pid}: {e}")
+
+        return data
 
     def fetch_group(self, group_id: str) -> dict:
         """Fetch group (pool) data including all entries."""
@@ -214,38 +242,41 @@ class ESPNApi:
                         if info:
                             prior_winner_names.add(info["name"])
 
-            # Set winners on First Round games
+            # Set winners on First Round games. Teams in prior_winner_names
+            # definitely won their First Round game. For games where neither
+            # team is in prior_winner_names (both were eliminated before the
+            # current round), assign the higher seed as winner — their runs
+            # are over so the choice doesn't affect current-round analysis,
+            # but we need all games resolved to advance the bracket tree.
             for game in bracket.games:
                 if game.team1.name in prior_winner_names:
                     game.winner = game.team1
                 elif game.team2.name in prior_winner_names:
                     game.winner = game.team2
+                elif not game.winner:
+                    game.winner = game.team1 if game.team1.seed <= game.team2.seed else game.team2
 
             bracket.results["First Round"] = [game.winner for game in bracket.games if game.winner]
 
-            # Advance through intermediate completed rounds if min_period > 2
+            # Advance through intermediate completed rounds if min_period > 2.
+            # The teams in prior_winner_names won ALL rounds before min_period,
+            # so they are the winners in every intermediate round as well.
             current_games = bracket.games.copy()
             for round_ind in range(1, min_period - 1):
                 if all(g.winner for g in current_games):
                     current_games = bracket.advance_round(current_games)
-                    # For intermediate rounds, all teams must have advanced
-                    # since a later round's props exist. Use actualOutcomeIds
-                    # from the next period's props to identify winners.
-                    next_period_winners: set[str] = set()
-                    for prop_info in prop_map.values():
-                        if prop_info["scoring_period"] == round_ind + 1:
-                            for oid in prop_info["actual_outcome_ids"]:
-                                info = outcome_map.get(oid)
-                                if info:
-                                    next_period_winners.add(info["name"])
-
                     for game in current_games:
-                        if game.team1.name in next_period_winners:
+                        if game.team1.name in prior_winner_names:
                             game.winner = game.team1
                             bracket.results[self.ROUND_NAMES[round_ind]].append(game.team1)
-                        elif game.team2.name in next_period_winners:
+                        elif game.team2.name in prior_winner_names:
                             game.winner = game.team2
                             bracket.results[self.ROUND_NAMES[round_ind]].append(game.team2)
+                        elif not game.winner:
+                            game.winner = (
+                                game.team1 if game.team1.seed <= game.team2.seed else game.team2
+                            )
+                            bracket.results[self.ROUND_NAMES[round_ind]].append(game.winner)
         else:
             # First Round props are available — use correctOutcomes directly
             for _prop_id, prop_info in prop_map.items():
@@ -264,9 +295,26 @@ class ESPNApi:
 
             bracket.results["First Round"] = [game.winner for game in bracket.games if game.winner]
 
-        # Build current and subsequent rounds from game tree
+        # Build current and subsequent rounds from game tree.
+        # Start from where prior-round reconstruction left off to avoid
+        # duplicating work and to ensure we use the same game objects.
+        start_round = max(min_period - 1, 1)
         current_games = bracket.games.copy()
-        for round_ind in range(1, 5):
+        for step in range(start_round):
+            # Set winners from already-populated results so advance_round()
+            # uses actual winners instead of randomly simulating.
+            round_winners = {t.name for t in bracket.results.get(self.ROUND_NAMES[step], [])}
+            for game in current_games:
+                if not game.winner and game.team1.name in round_winners:
+                    game.winner = game.team1
+                elif not game.winner and game.team2.name in round_winners:
+                    game.winner = game.team2
+            # Advance all but the last completed round — the main loop
+            # expects current_games to be the last fully-completed round
+            # so it can call advance_round() to enter the current round.
+            if step < start_round - 1 and all(g.winner for g in current_games):
+                current_games = bracket.advance_round(current_games)
+        for round_ind in range(start_round, 5):
             if all(g.winner for g in current_games):
                 current_games = bracket.advance_round(current_games)
                 for _prop_id, prop_info in prop_map.items():

--- a/src/bigdance/espn_tc_scraper.py
+++ b/src/bigdance/espn_tc_scraper.py
@@ -3,7 +3,7 @@
 @File    :   espn_tc_scraper.py
 @Time    :   2025/03/17
 @Author  :   Taylor Firman
-@Version :   0.8.2
+@Version :   0.8.3
 @Contact :   tefirman@gmail.com
 @Desc    :   ESPN Tournament Challenge integration via the Gambit JSON API
 """

--- a/src/bigdance/wn_cbb_scraper.py
+++ b/src/bigdance/wn_cbb_scraper.py
@@ -3,7 +3,7 @@
 @File    :   wn_cbb_elo.py
 @Time    :   2024/02/22 10:58:06
 @Author  :   Taylor Firman
-@Version :   0.8.2
+@Version :   0.8.3
 @Contact :   tefirman@gmail.com
 @Desc    :   Elo ratings parser for the Warren Nolan college sports website (no affiliation)
 """


### PR DESCRIPTION
## Summary
- **fetch_challenge()** now retrieves propositions from all prior scoring periods via the `scoringPeriodId` query param, so entry picks from earlier rounds can be resolved and bracket results are complete
- **build_actual_bracket()** hardened to handle partial ESPN data as a fallback: assigns higher seeds as default winners for unknowable prior round games and fixes game tree advancement to avoid duplicating/skipping rounds

## Context
ESPN's Gambit API only returns propositions for the current scoring period. Once the Sweet 16 started, R64/R32 props disappeared, causing:
1. Wrong round analyzed for game importance (16 games shown instead of 6)
2. Completed Sweet 16 games not detected
3. Entry picks unresolvable → 0% win probability for all entries

## Test plan
- [x] Verified `build_actual_bracket()` produces correct results (32 R1, 16 R2, correct S16 winners)
- [x] Verified entry brackets fully resolve (32 First Round picks, not 8)
- [x] Verified `infer_current_round()` returns "Sweet 16"
- [x] Verified completed games (Iowa, Purdue) show in results
- [x] Manual testing of tracker app with live ESPN data

🤖 Generated with [Claude Code](https://claude.com/claude-code)