### PR TITLE
Fix Championship round missing from bracket simulation

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,2 +1,2 @@
 streamlit>=1.55.0
-bigdance>=0.8.3
+bigdance>=0.8.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bigdance"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
   "numpy>=1.23",
   "pandas>=1.5",

--- a/src/bigdance/__init__.py
+++ b/src/bigdance/__init__.py
@@ -27,7 +27,7 @@ from .cbb_brackets import Bracket, Game, Pool, Team
 from .espn_tc_scraper import ESPNApi, GameImportanceAnalyzer
 from .wn_cbb_scraper import Matchups, Schedule, Standings, elo_prob
 
-__version__ = "0.8.3"
+__version__ = "0.8.4"
 __author__ = "Taylor Firman"
 __email__ = "tefirman@gmail.com"
 

--- a/src/bigdance/bigdance_integration.py
+++ b/src/bigdance/bigdance_integration.py
@@ -3,7 +3,7 @@
 @File    :   bigdance_integration.py
 @Time    :   2025/01/19
 @Author  :   Taylor Firman
-@Version :   0.8.3
+@Version :   0.8.4
 @Contact :   tefirman@gmail.com
 @Desc    :   Integration module between Warren Nolan scraper and bracket simulator
 """

--- a/src/bigdance/bracket_analysis.py
+++ b/src/bigdance/bracket_analysis.py
@@ -3,7 +3,7 @@
 @File    :   bracket_analysis.py
 @Time    :   2024/02/13
 @Author  :   Taylor Firman
-@Version :   0.8.3
+@Version :   0.8.4
 @Contact :   tefirman@gmail.com
 @Desc    :   Analyzing trends in March Madness bracket pool simulations
 """

--- a/src/bigdance/espn_tc_scraper.py
+++ b/src/bigdance/espn_tc_scraper.py
@@ -3,7 +3,7 @@
 @File    :   espn_tc_scraper.py
 @Time    :   2025/03/17
 @Author  :   Taylor Firman
-@Version :   0.8.3
+@Version :   0.8.4
 @Contact :   tefirman@gmail.com
 @Desc    :   ESPN Tournament Challenge integration via the Gambit JSON API
 """

--- a/src/bigdance/espn_tc_scraper.py
+++ b/src/bigdance/espn_tc_scraper.py
@@ -48,7 +48,14 @@ class ESPNApi:
 
     GAMBIT_API_BASE = "https://gambit-api.fantasy.espn.com/apis/v1/challenges"
 
-    ROUND_NAMES = ["First Round", "Second Round", "Sweet 16", "Elite 8", "Final Four"]
+    ROUND_NAMES = [
+        "First Round",
+        "Second Round",
+        "Sweet 16",
+        "Elite 8",
+        "Final Four",
+        "Championship",
+    ]
 
     def __init__(self, women: bool = False, cache_dir: Optional[str] = None):
         """
@@ -314,7 +321,7 @@ class ESPNApi:
             # so it can call advance_round() to enter the current round.
             if step < start_round - 1 and all(g.winner for g in current_games):
                 current_games = bracket.advance_round(current_games)
-        for round_ind in range(start_round, 5):
+        for round_ind in range(start_round, len(self.ROUND_NAMES)):
             if all(g.winner for g in current_games):
                 current_games = bracket.advance_round(current_games)
                 for _prop_id, prop_info in prop_map.items():
@@ -325,10 +332,14 @@ class ESPNApi:
                                 if game.team1.name == winner_info["name"]:
                                     game.winner = game.team1
                                     bracket.results[self.ROUND_NAMES[round_ind]].append(game.team1)
+                                    if self.ROUND_NAMES[round_ind] == "Championship":
+                                        bracket.results["Champion"] = game.team1  # type: ignore[assignment]
                                     break
                                 elif game.team2.name == winner_info["name"]:
                                     game.winner = game.team2
                                     bracket.results[self.ROUND_NAMES[round_ind]].append(game.team2)
+                                    if self.ROUND_NAMES[round_ind] == "Championship":
+                                        bracket.results["Champion"] = game.team2  # type: ignore[assignment]
                                     break
             else:
                 if not bracket.results[self.ROUND_NAMES[round_ind]]:
@@ -377,7 +388,7 @@ class ESPNApi:
             if not team:
                 continue
             rounds_won = max_period - 1
-            for round_idx in range(min(rounds_won, 5)):
+            for round_idx in range(min(rounds_won, len(self.ROUND_NAMES))):
                 if team not in bracket.results[self.ROUND_NAMES[round_idx]]:
                     bracket.results[self.ROUND_NAMES[round_idx]].append(team)
                 if round_idx == 0:

--- a/src/bigdance/wn_cbb_scraper.py
+++ b/src/bigdance/wn_cbb_scraper.py
@@ -3,7 +3,7 @@
 @File    :   wn_cbb_elo.py
 @Time    :   2024/02/22 10:58:06
 @Author  :   Taylor Firman
-@Version :   0.8.3
+@Version :   0.8.4
 @Contact :   tefirman@gmail.com
 @Desc    :   Elo ratings parser for the Warren Nolan college sports website (no affiliation)
 """


### PR DESCRIPTION
## Summary
- `ROUND_NAMES` was missing "Championship", so `build_actual_bracket()` never processed scoring period 6 and `build_entry_bracket()` capped pick resolution at Final Four
- Entries with championship picks (e.g. Shannon picking UConn to win it all) showed 0% win probability even when their champion was still alive
- Also sets `bracket.results["Champion"]` when a Championship winner is found in actual results

## Test plan
- [x] All existing tests pass (52 passed)
- [x] Linting and formatting pass
- [ ] Verify in tracker app that entries with live championship picks now show nonzero win probability

🤖 Generated with [Claude Code](https://claude.com/claude-code)