### PR TITLE
Fix champion pick resolution using period 6 proposition

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,2 +1,2 @@
 streamlit>=1.55.0
-bigdance>=0.8.4
+bigdance>=0.8.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bigdance"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
   "numpy>=1.23",
   "pandas>=1.5",

--- a/src/bigdance/__init__.py
+++ b/src/bigdance/__init__.py
@@ -27,7 +27,7 @@ from .cbb_brackets import Bracket, Game, Pool, Team
 from .espn_tc_scraper import ESPNApi, GameImportanceAnalyzer
 from .wn_cbb_scraper import Matchups, Schedule, Standings, elo_prob
 
-__version__ = "0.8.4"
+__version__ = "0.8.5"
 __author__ = "Taylor Firman"
 __email__ = "tefirman@gmail.com"
 

--- a/src/bigdance/bigdance_integration.py
+++ b/src/bigdance/bigdance_integration.py
@@ -3,7 +3,7 @@
 @File    :   bigdance_integration.py
 @Time    :   2025/01/19
 @Author  :   Taylor Firman
-@Version :   0.8.4
+@Version :   0.8.5
 @Contact :   tefirman@gmail.com
 @Desc    :   Integration module between Warren Nolan scraper and bracket simulator
 """

--- a/src/bigdance/bracket_analysis.py
+++ b/src/bigdance/bracket_analysis.py
@@ -3,7 +3,7 @@
 @File    :   bracket_analysis.py
 @Time    :   2024/02/13
 @Author  :   Taylor Firman
-@Version :   0.8.4
+@Version :   0.8.5
 @Contact :   tefirman@gmail.com
 @Desc    :   Analyzing trends in March Madness bracket pool simulations
 """

--- a/src/bigdance/espn_tc_scraper.py
+++ b/src/bigdance/espn_tc_scraper.py
@@ -3,7 +3,7 @@
 @File    :   espn_tc_scraper.py
 @Time    :   2025/03/17
 @Author  :   Taylor Firman
-@Version :   0.8.4
+@Version :   0.8.5
 @Contact :   tefirman@gmail.com
 @Desc    :   ESPN Tournament Challenge integration via the Gambit JSON API
 """

--- a/src/bigdance/espn_tc_scraper.py
+++ b/src/bigdance/espn_tc_scraper.py
@@ -80,8 +80,8 @@ class ESPNApi:
 
         ESPN only returns propositions for the current scoring period.  To
         build a complete outcome map (needed for resolving entry picks that
-        reference earlier rounds), we fetch each prior period's propositions
-        and merge them into the response.
+        reference earlier or later rounds), we fetch each other period's
+        propositions and merge them into the response.
         """
         url = f"{self.GAMBIT_API_BASE}/{self.challenge_slug}"
         resp = requests.get(url, timeout=30)
@@ -92,10 +92,10 @@ class ESPNApi:
         current_prop_ids = {p["id"] for p in data.get("propositions", [])}
         current_period = data.get("currentScoringPeriod", {}).get("id", 1)
 
-        # Fetch propositions from prior scoring periods
+        # Fetch propositions from other scoring periods (prior and future)
         for period in data.get("scoringPeriods", []):
             pid = period.get("id", 0)
-            if pid >= current_period:
+            if pid == current_period:
                 continue
             try:
                 prior_resp = requests.get(url, params={"scoringPeriodId": pid}, timeout=30)
@@ -374,7 +374,11 @@ class ESPNApi:
 
         # periodReached = the furthest scoring period this team reaches.
         # A team with periodReached=2 wins R1 (reaches R2), so rounds_won = periodReached - 1.
+        # Note: both finalists have periodReached=6 (both reach the Championship game),
+        # so we identify the champion from the scoring period 6 proposition pick.
+        prop_map = self._build_prop_map(challenge)
         team_max_period: dict[str, int] = {}
+        champion_name: Optional[str] = None
         for pick in picks:
             outcome_id = pick["outcomesPicked"][0]["outcomeId"]
             period_reached = pick.get("periodReached", 1)
@@ -382,6 +386,10 @@ class ESPNApi:
             if info:
                 name = info["name"]
                 team_max_period[name] = max(team_max_period.get(name, 0), period_reached)
+            # Identify the champion from the period 6 (Championship) proposition
+            prop_info = prop_map.get(pick.get("propositionId", ""))
+            if prop_info and prop_info["scoring_period"] == 6 and info:
+                champion_name = info["name"]
 
         for team_name, max_period in team_max_period.items():
             team = team_by_name.get(team_name)
@@ -397,9 +405,11 @@ class ESPNApi:
                             game.winner = team
                             break
 
-            if max_period >= 6:
-                bracket.results["Championship"] = [team]
-                bracket.results["Champion"] = team  # type: ignore[assignment]
+        # Set the champion from the period 6 proposition pick
+        if champion_name and champion_name in team_by_name:
+            champ = team_by_name[champion_name]
+            bracket.results["Championship"] = [champ]
+            bracket.results["Champion"] = champ  # type: ignore[assignment]
 
         bracket.log_probability = bracket.calculate_log_probability()
         bracket.identify_underdogs()

--- a/src/bigdance/wn_cbb_scraper.py
+++ b/src/bigdance/wn_cbb_scraper.py
@@ -3,7 +3,7 @@
 @File    :   wn_cbb_elo.py
 @Time    :   2024/02/22 10:58:06
 @Author  :   Taylor Firman
-@Version :   0.8.4
+@Version :   0.8.5
 @Contact :   tefirman@gmail.com
 @Desc    :   Elo ratings parser for the Warren Nolan college sports website (no affiliation)
 """


### PR DESCRIPTION
## Summary
- `fetch_challenge()` only fetched prior scoring periods, missing the Championship (period 6) proposition — so the championship outcome ID couldn't be resolved from the outcome map
- `build_entry_bracket()` used a `periodReached >= 6` heuristic that couldn't distinguish between the two finalists (both reach period 6), so whichever was processed last became the "champion"
- Now `fetch_challenge()` fetches all scoring periods (prior and future), and the champion is identified from the actual period 6 proposition pick

Follow-up to #17

## Test plan
- [x] All existing tests pass (52 passed)
- [x] Linting and formatting pass
- [x] Verified Shannon's champion correctly resolves to UConn (not Purdue)
- [x] Pool simulation shows Shannon at ~11% win probability (was 0%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)